### PR TITLE
Prevent duplicate tasks from being added

### DIFF
--- a/src/main/java/commands/AddCommand.java
+++ b/src/main/java/commands/AddCommand.java
@@ -1,5 +1,6 @@
 package commands;
 
+import exceptions.GrokInvalidUserInputException;
 import storage.Storage;
 import tasklist.TaskList;
 import tasks.Task;
@@ -22,12 +23,19 @@ public class AddCommand extends Command {
 
     /**
      * Execution actions:
+     * - Ensure that task description is unique before adding
      * - Add task to the task list
      * - Write updated task list to storage
      * - Print new task and inform user on total tasks
      */
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) {
+        boolean isDuplicate = tasks.checkIfDuplicate(task);
+
+        if (isDuplicate) {
+            return "Duplicate task description detected - task not saved.";
+        }
+
         tasks.addTask(task);
         storage.writeToTextStorage(tasks);
         return "Got it. I've added this task:\n  "

--- a/src/main/java/tasklist/TaskList.java
+++ b/src/main/java/tasklist/TaskList.java
@@ -1,6 +1,7 @@
 package tasklist;
 
 import java.util.ArrayList;
+import java.util.Objects;
 
 import tasks.Task;
 
@@ -50,6 +51,12 @@ public class TaskList {
 
     public void addTask(Task t) {
         tasks.add(t);
+    }
+
+    public boolean checkIfDuplicate(Task t) {
+        return tasks.stream()
+                .map(Task::getDescription)
+                .anyMatch(description -> Objects.equals(description, t.getDescription()));
     }
 
     /**


### PR DESCRIPTION
Previously, duplicate tasks could be easily added into the task list, which is undesirable as the user may be confused about why multiple tasks with the same description are present.

A duplicate-checking method has been added to scan and ensure that no task descriptions match before a task can be added. If a duplicate task is added, addition of the task is aborted and the user is informed.

Streams are used as part of this feature to convey the stateless nature of the duplicate checker method, allowing for multi-threaded use if necessary.